### PR TITLE
Add port-channel generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,6 @@ ENV/
 # Rope project settings
 .ropeproject
 config.json
+
+# lis-cain
+output/*.txt

--- a/README.md
+++ b/README.md
@@ -12,3 +12,30 @@ lis-cain requires custom tftpy which you can clone from https://github.com/atonk
         execute("/opt/lis-cain/dhcp-hook.py", clip, swmac, swport);
     }
 ```
+
+## port-channel generator
+```
+usage: portchan.py [-h] -p PREFIX [-f FIRST] [-m MODE] [-d DISTSW]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -p PREFIX, --prefix PREFIX
+  -f FIRST, --first FIRST
+  -m MODE, --mode MODE
+  -d DISTSW, --distsw DISTSW
+```
+
+#### --prefix
+Prefix for distribution switch ports. Can be given in format "Gi" or "Gi0".  
+Choosing "Gi" takes module number from port configuration. In case of fixed-configuration switches, we usually want to override it to "Gi0" or "Gi1/0"
+
+#### --first
+Number of first port-channel interface. Defaults to 5 leaving four free for core connections.
+
+#### --mode
+Operating mode e.g. active or desirable
+
+#### --distsw
+Specify distribution switches. Can be used 0, 1 or more times. Without using this all configs are generated.  
+Useful when dealing with different switches in distribution layer.  
+Just run once with most common settings and afterwards use this option to overwrite different settings.

--- a/cabling.j2
+++ b/cabling.j2
@@ -1,0 +1,8 @@
+Cabling info for {{ name }}
+{% for switch, ports in switches.items() %}
+{%- for port in ports %}
+{{ '{:8} | {}'.format(port, switch) }}
+{%- endfor %}
+{%- endfor %}
+
+

--- a/portchan.j2
+++ b/portchan.j2
@@ -1,0 +1,21 @@
+{% for switch in switches %}
+{% for slave in switch.slaves %}
+interface {{ slave }}
+ no shutdown
+ description {{ switch.switch }}
+ switchport
+ switchport trunk encapsulation dot1q
+ switchport mode trunk
+ switchport trunk allowed vlan {{ switch.vlans }}
+ channel-group {{ switch.ponum }} mode {{ switch.mode }}
+ load-interval 30
+{% endfor %}
+interface port-channel {{ switch.ponum }}
+ no shutdown
+ description {{ switch.switch }}
+ switchport
+ switchport trunk encapsulation dot1q
+ switchport mode trunk
+ switchport trunk allowed vlan {{ switch.vlans }}
+ load-interval 30
+{% endfor %}

--- a/portchan.py
+++ b/portchan.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+
+import os
+import argparse
+import json
+import jinja2
+
+# These are added to all port channels
+DEFAULT_VLANS = [1]
+
+if not os.path.isdir('output'):
+    os.mkdir('output')
+
+parser = argparse.ArgumentParser('portchan.py')
+parser.add_argument('-p', '--prefix', required=True)
+parser.add_argument('-f', '--first', type=int, default=5)
+parser.add_argument('-m', '--mode', default='desirable')
+parser.add_argument('-d', '--distsw', default=[], action='append')
+
+args = parser.parse_args()
+
+prefix = args.prefix
+first = args.first
+mode = args.mode
+distswlist = args.distsw
+
+class Switch(object):
+    def __init__(self, switch, vlans, ponum, mode, slaves):
+        self.switch = switch
+        self.vlans = vlans
+        self.ponum = ponum
+        self.mode = mode
+        self.slaves = slaves
+
+def gen_port(prefix, distport):
+    module, portnum = distport.split('/')
+    if not prefix[-1].isdigit():
+        prefix += module
+    port = '{}/{}'.format(prefix, portnum)
+
+    return port
+
+with open('config.json', 'r') as f:
+    config = json.load(f)
+
+for distsw in config['mapping'].values():
+    distswname = distsw['name']
+    if distswlist and not distswname in distswlist:
+        continue
+
+    ponum = first
+
+    switchdict = {}
+    for distport, accessw in distsw['maps'].items():
+        if not accessw in switchdict.keys():
+            switchdict[accessw] = [gen_port(prefix, distport)]
+        else:
+            switchdict[accessw].append(gen_port(prefix, distport))
+
+    switches = []
+    for switch, distports in switchdict.items():
+        swconf = config['switches'][switch]
+        if '_include' in swconf.keys():
+            swgrp = config['switchgroups'][swconf['_include']]
+            for option in swgrp:
+                if not option in swconf.keys():
+                    swconf[option] = swgrp[option]
+
+        vlanlist = set()
+        for vlan in DEFAULT_VLANS:
+            vlanlist.add(vlan)
+        vlanlist.add(swconf['mgmt_vlan'])
+        vlanlist.add(swconf['visitor_access_vlan'])
+        vlanlist = list(vlanlist)
+        vlanlist.sort()
+
+        vlans = ','.join(str(vlan) for vlan in vlanlist)
+        switches.append(Switch(switch, vlans, ponum, mode, distports))
+
+        ponum+=1
+
+    with open('portchan.j2') as f:
+        tmpl = jinja2.Template(f.read())
+    rendered = tmpl.render(switches=switches)
+    outfile = 'output/portchan-{}.txt'.format(distswname)
+    with open(outfile, 'w') as f:
+        f.write(rendered)
+    print('Configuration written into file {}'.format(outfile))
+
+    with open('cabling.j2') as f:
+        tmpl = jinja2.Template(f.read())
+    rendered = tmpl.render(name=distswname, switches=switchdict)
+    outfile = 'output/cabling-{}.txt'.format(distswname)
+    with open(outfile, 'w') as f:
+        f.write(rendered)
+    print('Cabling info written into file {}'.format(outfile))
+


### PR DESCRIPTION
This port-channel generator is used to generate port-channel configurations for distribution switches.
Makes deploying faster by cutting one configuration step

Just generate configuration snippets and use yrlbnry to insert them into network.